### PR TITLE
Change fmt.print os.exit to log.fatal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Dev/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Get-Gooo
 
 The simple scaffolding CLI tool for Go projects.
+
+Run with
+
+```shell
+go run *.go
+```

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Tmmcmasters/Get-Gooo
 
-go 1.24.3
+go 1.25.1

--- a/helper.go
+++ b/helper.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// downloadFile downloads a file from the given URL to the specified path
+func downloadFile(url, path string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d %s", resp.StatusCode, resp.Status)
+	}
+
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	return err
+}
+
+// extractZip extracts a ZIP file to the target directory, stripping the top-level directory
+func extractZip(zipPath, targetDir string) error {
+	reader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	for _, file := range reader.File {
+		// Strip the top-level directory (e.g., "Gooo-main/")
+		parts := strings.SplitN(file.Name, string(os.PathSeparator), 2)
+		var filePath string
+		if len(parts) > 1 {
+			filePath = filepath.Join(targetDir, parts[1])
+		} else {
+			filePath = filepath.Join(targetDir, file.Name)
+		}
+
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(filePath, file.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+			return err
+		}
+
+		outFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+		if err != nil {
+			return err
+		}
+
+		rc, err := file.Open()
+		if err != nil {
+			outFile.Close()
+			return err
+		}
+
+		_, err = io.Copy(outFile, rc)
+		outFile.Close()
+		rc.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"archive/zip"
 	"bufio"
 	"fmt"
-	"io"
-	"net/http"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,16 +17,14 @@ func main() {
 	targetDir := strings.TrimSpace(scanner.Text())
 
 	if targetDir == "" {
-		fmt.Println("Error: Directory cannot be empty.")
-		os.Exit(1)
+		log.Fatalf("Error: Directory cannot be empty.")
 	}
 
 	// Expand ~ to home directory if used
 	if strings.HasPrefix(targetDir, "~") {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			fmt.Printf("Error: Could not resolve home directory: %v\n", err)
-			os.Exit(1)
+			log.Fatalf("Error: Could not resolve home directory: %v\n", err)
 		}
 		targetDir = filepath.Join(home, targetDir[1:])
 	}
@@ -36,14 +32,12 @@ func main() {
 	// Convert to absolute path for consistency
 	targetDir, err := filepath.Abs(targetDir)
 	if err != nil {
-		fmt.Printf("Error: Could not resolve absolute path for %s: %v\n", targetDir, err)
-		os.Exit(1)
+		log.Fatalf("Error: Could not resolve absolute path for %s: %v\n", targetDir, err)
 	}
 
 	// Create target directory if it doesn't exist
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		fmt.Printf("Error: Could not create directory %s: %v\n", targetDir, err)
-		os.Exit(1)
+		log.Fatalf("Error: Could not create directory %s: %v\n", targetDir, err)
 	}
 
 	// Download the ZIP file
@@ -51,15 +45,13 @@ func main() {
 	zipPath := filepath.Join(targetDir, "gooo.zip")
 	fmt.Printf("Downloading Gooo repository to %s...\n", zipPath)
 	if err := downloadFile(zipURL, zipPath); err != nil {
-		fmt.Printf("Error: Failed to download repository: %v\n", err)
-		os.Exit(1)
+		log.Fatalf("Error: Failed to download repository: %v\n", err)
 	}
 
 	// Extract the ZIP file
 	fmt.Printf("Extracting %s to %s...\n", zipPath, targetDir)
 	if err := extractZip(zipPath, targetDir); err != nil {
-		fmt.Printf("Error: Failed to extract ZIP file: %v\n", err)
-		os.Exit(1)
+		log.Fatalf("Error: Failed to extract ZIP file: %v\n", err)
 	}
 
 	// Remove the ZIP file
@@ -68,76 +60,4 @@ func main() {
 	}
 
 	fmt.Printf("Success! Gooo project is scaffolded in %s\n", targetDir)
-}
-
-// downloadFile downloads a file from the given URL to the specified path
-func downloadFile(url, path string) error {
-	resp, err := http.Get(url)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d %s", resp.StatusCode, resp.Status)
-	}
-
-	out, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, resp.Body)
-	return err
-}
-
-// extractZip extracts a ZIP file to the target directory, stripping the top-level directory
-func extractZip(zipPath, targetDir string) error {
-	reader, err := zip.OpenReader(zipPath)
-	if err != nil {
-		return err
-	}
-	defer reader.Close()
-
-	for _, file := range reader.File {
-		// Strip the top-level directory (e.g., "Gooo-main/")
-		parts := strings.SplitN(file.Name, string(os.PathSeparator), 2)
-		var filePath string
-		if len(parts) > 1 {
-			filePath = filepath.Join(targetDir, parts[1])
-		} else {
-			filePath = filepath.Join(targetDir, file.Name)
-		}
-
-		if file.FileInfo().IsDir() {
-			if err := os.MkdirAll(filePath, file.Mode()); err != nil {
-				return err
-			}
-			continue
-		}
-
-		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
-			return err
-		}
-
-		outFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
-		if err != nil {
-			return err
-		}
-
-		rc, err := file.Open()
-		if err != nil {
-			outFile.Close()
-			return err
-		}
-
-		_, err = io.Copy(outFile, rc)
-		outFile.Close()
-		rc.Close()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
Fatal is equivalent to [Print](https://pkg.go.dev/log#Print) followed by a call to [os.Exit](https://pkg.go.dev/os#Exit)(1). [ref](https://pkg.go.dev/log#Fatal)
Create separate helper file
